### PR TITLE
Replace hardcoded PM group ID with name-based lookup

### DIFF
--- a/kaplancloudaccounts/forms.py
+++ b/kaplancloudaccounts/forms.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from django import forms
 from django.contrib.auth import password_validation
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
@@ -83,7 +83,7 @@ class UserRegistrationForm(forms.ModelForm):
             user.save()
             token = self.cleaned_data["token"]
             if token.user_type == 1:
-                user.groups.add(1)
+                user.groups.add(Group.objects.get(name="PM"))
                 user.is_staff = True
                 user.save()
             token.user = user

--- a/kaplancloudaccounts/tests.py
+++ b/kaplancloudaccounts/tests.py
@@ -146,13 +146,13 @@ class UserRegistrationFormTests(TestCase):
     def test_save_pm_token_sets_staff_and_group(self):
         from .forms import UserRegistrationForm
 
-        Group.objects.create(id=1, name="PM")
+        Group.objects.create(name="PM")
         pm_token = UserRegistrationToken.objects.create(user_type=1)
         form = UserRegistrationForm(data=self._form_data(token=pm_token.token))
         self.assertTrue(form.is_valid(), form.errors)
         user = form.save()
         self.assertTrue(user.is_staff)
-        self.assertTrue(user.groups.filter(id=1).exists())
+        self.assertTrue(user.groups.filter(name="PM").exists())
 
     def test_save_translator_token_not_staff(self):
         from .forms import UserRegistrationForm


### PR DESCRIPTION
Replaces user.groups.add(1) with Group.objects.get(name="PM") so group membership no longer depends on the fixture's primary key value. Updates the corresponding test to create and assert the group by name.

https://claude.ai/code/session_01EaeBCyHpEPgy7pq2Zk4c8h